### PR TITLE
Use action cache for ACE

### DIFF
--- a/.github/workflows/cache-ace-13.0.4-common.yml
+++ b/.github/workflows/cache-ace-13.0.4-common.yml
@@ -1,12 +1,15 @@
 name: ACE caching for 13.0.4
-
+#
+# This job should keep the cache from expiring, and will download 
+# ACE 13.0.4 if the URL in the "Install ACE" step is valid.
+#
 on:
   workflow_call:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
   schedule:
     - cron: "15 5 * * 1,4"
-    
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/cache-ace-13.0.4-common.yml
+++ b/.github/workflows/cache-ace-13.0.4-common.yml
@@ -1,0 +1,49 @@
+name: ACE caching for 13.0.4
+
+on:
+  workflow_call:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+  schedule:
+    - cron: "15 5 * * 1,4"
+    
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v4
+
+      - name: Cache ACE install
+        id: cache-ace
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-ace-install
+        with:
+          # ACE files are stored in `~/ace` and `~/aceconfig`
+          path: |
+            ~/ace
+            ~/aceconfig
+          key: ace-13.0.4.0
+
+      - name: Install ACE
+        if: ${{ steps.cache-ace.outputs.cache-hit != 'true' }}
+        shell: bash
+        run: |
+          set -e
+          set -x
+          mkdir ~/ace
+          cd ~/ace
+          aria2c -s 10 -j 10 -x 10 'https://iwm.dhe.ibm.com/sdfdl/v2/regs2/mbford/Xa.2/Xb.WJL1CuPI9hrjbl5VK-0AgKPz0gSRFL7zISIj9CH0ITw/Xc.13.0.4.0-ACE-LINUX64-EVALUATION.tar.gz/Xd./Xf.lPr.D1vk/Xg.13433147/Xi.swg-wmbfd/XY.regsrvs/XZ.LsWwRH_QexOKp-RulUB2Ihg9u25lKD6J/13.0.4.0-ACE-LINUX64-EVALUATION.tar.gz'
+          tar --exclude 'ace-13.0.4.0/tools' --exclude 'ace-13.0.4.0/server/nodejs*' -xf 13.0.4.0-ACE-LINUX64-EVALUATION.tar.gz
+          rm 13.0.4.0-ACE-LINUX64-EVALUATION.tar.gz
+          set +x
+          ~/ace/ace-13.0.4.0/ace accept license silently
+          . ~/ace/ace-13.0.4.0/server/bin/mqsiprofile
+          mqsilist
+          
+          # This is a hack: we're putting crane into the ace cache . . . 
+          echo ========================================================================
+          echo Installing crane
+          echo ========================================================================
+          curl --location -fs https://github.com/google/go-containerregistry/releases/download/v0.20.1/go-containerregistry_Linux_x86_64.tar.gz | tar -xzvf -

--- a/.github/workflows/cache-experiments.yml
+++ b/.github/workflows/cache-experiments.yml
@@ -12,6 +12,7 @@ jobs:
     uses: ./.github/workflows/cache-ace-13.0.4-common.yml
 
   build:
+    needs: ace-cache
     runs-on: ubuntu-latest
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/cache-experiments.yml
+++ b/.github/workflows/cache-experiments.yml
@@ -3,16 +3,9 @@ name: ACE application build with caching
 on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
-  # Triggers the workflow on push or pull request events but only for the main branch
-  push:
-    branches: [ action-cache ]
 
 jobs:
-  ace-cache:
-    uses: ./.github/workflows/cache-ace-13.0.4-common.yml
-
   build:
-    needs: ace-cache
     runs-on: ubuntu-latest
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/cache-experiments.yml
+++ b/.github/workflows/cache-experiments.yml
@@ -3,15 +3,128 @@ name: ACE application build with caching
 on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    branches: [ action-cache ]
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Install aria2
-        shell: bash
-        run: |
-          sudo apt-get install -y aria2
-
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
+
+      - name: Cache ACE install
+        id: cache-ace
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-ace-install
+        with:
+          # ACE files are stored in `~/ace` and `~/aceconfig`
+          path: |
+            ~/ace
+            ~/aceconfig
+          key: ace-13.0.4.0
+
+      - name: Install ACE
+        if: ${{ steps.cache-ace.outputs.cache-hit != 'true' }}
+        shell: bash
+        run: |
+          set -e
+          set -x
+          mkdir ~/ace
+          cd ~/ace
+          aria2c -s 10 -j 10 -x 10 'https://iwm.dhe.ibm.com/sdfdl/v2/regs2/mbford/Xa.2/Xb.WJL1CuPI9hrjbl5VK-0AgKPz0gSRFL7zISIj9CH0ITw/Xc.13.0.4.0-ACE-LINUX64-EVALUATION.tar.gz/Xd./Xf.lPr.D1vk/Xg.13433147/Xi.swg-wmbfd/XY.regsrvs/XZ.LsWwRH_QexOKp-RulUB2Ihg9u25lKD6J/13.0.4.0-ACE-LINUX64-EVALUATION.tar.gz'
+          tar --exclude 'ace-13.0.4.0/tools' --exclude 'ace-13.0.4.0/server/nodejs*' -xf 13.0.4.0-ACE-LINUX64-EVALUATION.tar.gz
+          rm 13.0.4.0-ACE-LINUX64-EVALUATION.tar.gz
+          set +x
+          ~/ace/ace-13.0.4.0/ace accept license silently
+          . ~/ace/ace-13.0.4.0/server/bin/mqsiprofile
+          mqsilist
+          
+          # This is a hack: we're putting crane into the ace cache . . . 
+          echo ========================================================================
+          echo Installing crane
+          echo ========================================================================
+          curl --location -fs https://github.com/google/go-containerregistry/releases/download/v0.20.1/go-containerregistry_Linux_x86_64.tar.gz | tar -xzvf -
+
+      - name: Run ACE commands
+        shell: bash
+        run: |
+          echo "Loading ACE profile"
+          export LICENSE=accept
+          . ~/ace/ace-13.0.*.*/server/bin/mqsiprofile
+          set -e # Fail on error - this must be done after the profile in case the container has the profile loaded already
+
+          echo ========================================================================
+          echo Building application
+          echo ========================================================================
+          # Using --compile-maps-and-schemas for 12.0.11 and later . . . 
+          ibmint package --input-path . --output-bar-file $PWD/tea-application-combined.bar --project TeaSharedLibraryJava --project TeaSharedLibrary --project TeaRESTApplication --compile-maps-and-schemas 
+
+          echo ========================================================================
+          echo Building unit tests
+          echo ========================================================================
+          # Create the unit test work directory
+          mqsicreateworkdir /tmp/test-work-dir
+          mqsibar -w /tmp/test-work-dir -a $PWD/tea-application-combined.bar 
+          # Build just the unit tests
+          ibmint deploy --input-path . --output-work-directory /tmp/test-work-dir --project TeaRESTApplication_UnitTest
+
+          echo ========================================================================
+          echo Running unit tests
+          echo ========================================================================
+          IntegrationServer -w /tmp/test-work-dir --no-nodejs --start-msgflows false --test-project TeaRESTApplication_UnitTest --test-junit-options --reports-dir=junit-reports
+          
+      - name: Create the container structure
+        run: |
+          echo "Loading ACE profile"
+          export LICENSE=accept
+          . ~/ace/ace-13.0.*.*/server/bin/mqsiprofile
+          set -e # Fail on error - this must be done after the profile in case the container has the profile loaded already
+
+          rm -rf /tmp/build
+          mkdir -p /tmp/build/home/aceuser/
+          echo ========================================================================
+          echo Creating work directory structure
+          echo ========================================================================
+          mqsicreateworkdir /tmp/build/home/aceuser/ace-server
+          mqsibar -w /tmp/build/home/aceuser/ace-server -a $PWD/tea-application-combined.bar
+          ibmint optimize server --work-dir /tmp/build/home/aceuser/ace-server
+
+          export DATE=$(date '+%Y%m%d%H%M%S')
+          export COMMIT=$(git log -1 --pretty=%h)
+          export TAG="$DATE"-"$COMMIT"
+          echo Setting container tag to "$TAG"
+          echo "$TAG" > /tmp/build/image-tag.txt
+          
+          cd /tmp/build
+          
+          chmod -R 777 .
+          echo ========================================================================
+          echo Create tar file of server contents
+          echo ========================================================================
+          # Must have the full directory tree from / in the tar file
+          tar -cvzf /tmp/build/crane-append-file.tar.gz home
+
+      - name: Create container image
+        shell: bash
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          CP_USERNAME: ${{ secrets.CP_USERNAME }}
+          CP_PASSWORD: ${{ secrets.CP_PASSWORD }}
+        run: |
+          cd /tmp/build
+          set -e
+          set -x
+
+          echo ========================================================================
+          echo Logging in 
+          echo ========================================================================
+          echo "${DOCKER_PASSWORD}" | ~/ace/crane auth login docker.io --username ${DOCKER_USERNAME} --password-stdin
+          echo "${CP_PASSWORD}" | ~/ace/crane auth login cp.icr.io --username ${CP_USERNAME} --password-stdin
+          echo ========================================================================
+          echo Appending server contents tar file to create new image
+          echo ========================================================================
+          #~/ace/crane append -b tdolby/experimental:ace-minimal-13.0.1.0-ubuntu -f /tmp/build/crane-append-file.tar.gz -t tdolby/experimental:tea-github-action-crane-`cat /tmp/build/image-tag.txt`

--- a/.github/workflows/cache-experiments.yml
+++ b/.github/workflows/cache-experiments.yml
@@ -8,6 +8,9 @@ on:
     branches: [ action-cache ]
 
 jobs:
+  ace-cache:
+    uses: ./.github/workflows/cache-ace-13.0.4-common.yml
+
   build:
     runs-on: ubuntu-latest
     steps:
@@ -25,28 +28,6 @@ jobs:
             ~/ace
             ~/aceconfig
           key: ace-13.0.4.0
-
-      - name: Install ACE
-        if: ${{ steps.cache-ace.outputs.cache-hit != 'true' }}
-        shell: bash
-        run: |
-          set -e
-          set -x
-          mkdir ~/ace
-          cd ~/ace
-          aria2c -s 10 -j 10 -x 10 'https://iwm.dhe.ibm.com/sdfdl/v2/regs2/mbford/Xa.2/Xb.WJL1CuPI9hrjbl5VK-0AgKPz0gSRFL7zISIj9CH0ITw/Xc.13.0.4.0-ACE-LINUX64-EVALUATION.tar.gz/Xd./Xf.lPr.D1vk/Xg.13433147/Xi.swg-wmbfd/XY.regsrvs/XZ.LsWwRH_QexOKp-RulUB2Ihg9u25lKD6J/13.0.4.0-ACE-LINUX64-EVALUATION.tar.gz'
-          tar --exclude 'ace-13.0.4.0/tools' --exclude 'ace-13.0.4.0/server/nodejs*' -xf 13.0.4.0-ACE-LINUX64-EVALUATION.tar.gz
-          rm 13.0.4.0-ACE-LINUX64-EVALUATION.tar.gz
-          set +x
-          ~/ace/ace-13.0.4.0/ace accept license silently
-          . ~/ace/ace-13.0.4.0/server/bin/mqsiprofile
-          mqsilist
-          
-          # This is a hack: we're putting crane into the ace cache . . . 
-          echo ========================================================================
-          echo Installing crane
-          echo ========================================================================
-          curl --location -fs https://github.com/google/go-containerregistry/releases/download/v0.20.1/go-containerregistry_Linux_x86_64.tar.gz | tar -xzvf -
 
       - name: Run ACE commands
         shell: bash

--- a/.github/workflows/cache-experiments.yml
+++ b/.github/workflows/cache-experiments.yml
@@ -1,0 +1,17 @@
+name: ACE application build with caching
+
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install aria2
+        shell: bash
+        run: |
+          sudo apt-get install -y aria2
+
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v4

--- a/.github/workflows/gitops-push.yml
+++ b/.github/workflows/gitops-push.yml
@@ -1,0 +1,22 @@
+name: Push to GitOps repo
+
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    branches: [ gitops-push ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v4
+
+      - name: Push PR to gitops repo
+        shell: bash
+        run: |
+          set -e
+          set -x
+          echo Hello


### PR DESCRIPTION
Use the github action cache to store the ACE product in order to avoid pulling container images repeatedly.